### PR TITLE
Fix bug preventing 2 different clients from reserving the same travel

### DIFF
--- a/src/main/java/org/zzpj/tabi/entities/Reservation.java
+++ b/src/main/java/org/zzpj/tabi/entities/Reservation.java
@@ -10,13 +10,22 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToOne;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.Getter;
 import lombok.Setter;
 
 @Entity
-@Table(name = "reservation")
+@Table(
+    name = "reservation",
+    uniqueConstraints = {
+        @UniqueConstraint(
+            name = "UniqueClientAndTravel",
+            columnNames = {"client", "travel"}
+        )
+    }
+)
 @Getter @Setter
 public class Reservation {
 
@@ -31,11 +40,11 @@ public class Reservation {
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
 
-    @OneToOne(cascade = CascadeType.ALL)
+    @ManyToOne(cascade = CascadeType.ALL)
     @JoinColumn(name = "client", referencedColumnName = "id")
     private Client client;
 
-    @OneToOne(cascade = CascadeType.ALL)
+    @ManyToOne(cascade = CascadeType.ALL)
     @JoinColumn(name = "travel", referencedColumnName = "id")
     private Travel travel;
 


### PR DESCRIPTION
Steps to reproduce the bug:

1. Add the following to the `data.sql` script:
```sql
INSERT INTO reservation (
    id,
    client,
    travel,
    price,
    guest_count
) VALUES (
    '00000000-0000-0001-0000-000000000002',
    '00000000-0000-0000-0000-000000000002',
    '00000000-0000-0000-0001-000000000001',
    2089.00,
    2
);
```
2. Run the app:
```console
$ mvn clean spring-boot:run
```
It won't build, because other client (`00000000-0000-0000-0000-000000000001`) already reserved this travel (`00000000-0000-0000-0001-000000000001`) which violates the `reservation_travel_key` constraint. This pull request fixes that.
